### PR TITLE
make cloud scraping a little more consistent

### DIFF
--- a/resources/lib/pages/__init__.py
+++ b/resources/lib/pages/__init__.py
@@ -175,7 +175,7 @@ class Sources(DisplayWindow):
             if g.premiumize_enabled() and g.get_setting('premiumize.cloudInspection') == 'true':
                 debrid['premiumize'] = True
 
-            self.usercloudSources = debrid_cloudfiles.sources().get_sources(debrid, query, episode)
+            self.usercloudSources = debrid_cloudfiles.sources().get_sources(debrid, query, episode, anilist_id)
             self.cloud_files += self.usercloudSources
 
         self.remainingProviders.remove('Cloud Inspection')


### PR DESCRIPTION
should improve cloud scraping a little. It is not the most precise, so should probably only be used if users can't find any proper sources. Meaning, it generally found the show, but if it was a part 1 or 2 of a season, it would always show up even if it was the wrong part. But better than not showing up at all I guess.

Also, there seems to be custom apis that SwagOtaku made and deployed with firebase. Since we don't have access to that we can really only hope it doesn't go down. There is also an https://armkai.vercel.app/api for kaito, but I'm not sure how it's deployed  either. So either hope swag otaku doesn't take those down or try to get a replica incase he does take them down.