### PR TITLE
Add MAL watchlist import support. 

### DIFF
--- a/default.py
+++ b/default.py
@@ -7,7 +7,7 @@ from resources.lib.ui.globals import g
 from resources.lib.ui.router import on_param, route, router_process
 from resources.lib.KaitoBrowser import KaitoBrowser
 from resources.lib.AniListBrowser import AniListBrowser
-from resources.lib.WatchlistIntegration import set_browser, add_watchlist, watchlist_update
+from resources.lib.WatchlistIntegration import set_browser, add_watchlist, watchlist_update, WATCHLIST_WATCHED_UPDATE
 import ast
 import sys
 
@@ -455,3 +455,5 @@ set_browser(_BROWSER)
 _add_last_watched()
 add_watchlist(MENU_ITEMS)
 router_process(g.PATH[1:], g.REQUEST_PARAMS)
+if g.PARAM_STRING == '':
+    WATCHLIST_WATCHED_UPDATE('', {'modal': 'false'})

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -542,5 +542,9 @@ msgid "Enable Season Parsing (Disable if Performance Issues)"
 msgstr ""
 
 msgctxt "#40381"
-msgid "Enable Season Scraping"
+msgid "Enable Source Scraping"
+msgstr ""
+
+msgctxt "#40382"
+msgid "Manual Watchlist Update"
 msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -529,6 +529,10 @@ msgctxt "#40377"
 msgid "Seconds before closing"
 msgstr ""
 
+msgctxt "#40378"
+msgid "Enable Gogo Scraping"
+msgstr ""
+
 msgctxt "#40379"
 msgid "Enable Source Scraping"
 msgstr ""
@@ -538,5 +542,9 @@ msgid "Enable Season Parsing (Disable if Performance Issues)"
 msgstr ""
 
 msgctxt "#40381"
-msgid "Enable Season Scraping"
+msgid "Enable Source Scraping"
+msgstr ""
+
+msgctxt "#40382"
+msgid "Manual Watchlist Update"
 msgstr ""

--- a/resources/lib/AniListBrowser.py
+++ b/resources/lib/AniListBrowser.py
@@ -79,7 +79,7 @@ class AniListBrowser(object):
             variables['format'] = [format_in.upper()]
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)
@@ -97,7 +97,7 @@ class AniListBrowser(object):
             variables['format'] = [format_in.upper()]
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)
@@ -136,7 +136,7 @@ class AniListBrowser(object):
             variables['format'] = [format_in.upper()]
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)
@@ -154,7 +154,7 @@ class AniListBrowser(object):
             variables['format'] = [format_in.upper()]
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime/list", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)
@@ -207,7 +207,7 @@ class AniListBrowser(object):
             }
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)
@@ -964,7 +964,7 @@ class AniListBrowser(object):
             variables["tags"] = tag_list
 
         anilist_list = self.shows_database.extract_trakt_page(
-            self._URL, query_path="search/anime/genre", variables=variables, dict_key=self.anime_list_key, page=page
+            self._URL, query_path="search/anime/genre", variables=variables, dict_key=self.anime_list_key, page=page, cached=1
             )
 
         self.list_builder.show_list_builder(anilist_list)

--- a/resources/lib/WatchlistFlavor/MyAnimeList.py
+++ b/resources/lib/WatchlistFlavor/MyAnimeList.py
@@ -123,6 +123,17 @@ class MyAnimeListWLF(WatchlistFlavorBase):
         url = self._to_url("users/@me/animelist")
         return self._process_status_view(url, params, status, page)
 
+    def get_watchlist(self, status=None, offset=0, page=1):
+        params = {
+            "status": status,
+            "sort": self.__get_sort(),
+            "limit": 100,
+            "offset": offset,
+            }
+
+        url = self._to_url("users/@me/animelist?fields=list_status")
+        return (self._get_request(url, headers=self.__headers(), params=params)).json()
+
     def get_watchlist_anime_entry(self, anilist_id):
         mal_id = self._get_mapping_id(anilist_id, 'mal_id')
 

--- a/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
+++ b/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
@@ -74,6 +74,9 @@ class WatchlistFlavorBase(object):
     def get_watchlist_status(self, status):
         raise NotImplementedError("get_watchlist_status should be implemented by subclass")
 
+    def get_watchlist(self):
+        raise NotImplementedError("get_watchlist should be implemented by subclass")
+
     def watchlist_update(self, episode, kitsu_id):
         raise NotImplementedError("watchlist_update should be implemented by subclass")
 

--- a/resources/lib/WatchlistFlavor/__init__.py
+++ b/resources/lib/WatchlistFlavor/__init__.py
@@ -64,6 +64,10 @@ class WatchlistFlavor(object):
         return WatchlistFlavor.__instance_flavor(name).get_watchlist_status(status)
 
     @staticmethod
+    def get_watchlist(name):
+        return WatchlistFlavor.__instance_flavor(name).get_watchlist()
+
+    @staticmethod
     def watchlist_status_request_pages(name, status, offset, page):
         return WatchlistFlavor.__instance_flavor(name).get_watchlist_status(status, offset, page)
 

--- a/resources/lib/database/anilist_sync/shows.py
+++ b/resources/lib/database/anilist_sync/shows.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 from resources.lib.database import anilist_sync
+from resources.lib.ui import database
 from resources.lib.ui.globals import g
 from resources.lib.modules.guard_decorators import (
     guard_against_none,
@@ -805,6 +806,15 @@ class AnilistSyncDatabase(anilist_sync.AnilistSyncDatabase):
                 for i in formatted_items
             ),
         )
+        anilist_ids = {}
+        for i in formatted_items:
+            anilist_ids[formatted_items[0]['info'].get("tvshow.anilist_id")] = formatted_items[0]['info'].get("tvshow.anilist_id")
+        episodes_watched = {}
+        for x in anilist_ids:
+            episodes_watched[x] = database.get_show(x)["watched_episodes"]
+        for x in episodes_watched:
+            if episodes_watched[x] > 0:
+                database.mark_episodes_watched(x, 1, 1, episodes_watched[x])
 
     @guard_against_none_or_empty(None, 1, 2, 3)
     def format_tmdb_episodes(self, list_to_update, anilist_id, tmdb_id=None, trakt_id=None):
@@ -844,6 +854,10 @@ class AnilistSyncDatabase(anilist_sync.AnilistSyncDatabase):
             ),
         )
 
+        episodes_watched = database.get_show(anilist_id)["watched_episodes"]
+        if episodes_watched > 0:
+            database.mark_episodes_watched(anilist_id, 1, 1, episodes_watched)
+
     @guard_against_none_or_empty(None, 1, 2, 3)
     def format_simkl_episodes(self, list_to_update, anilist_id, tmdb_id=None, trakt_id=None):
         # formatted_items = self._format_objects(self._identify_episodes_to_update(list_to_update))
@@ -881,6 +895,11 @@ class AnilistSyncDatabase(anilist_sync.AnilistSyncDatabase):
                 for i in to_insert
             ),
         )
+
+
+        episodes_watched = database.get_show(anilist_id)["watched_episodes"]
+        if episodes_watched > 0:
+            database.mark_episodes_watched(anilist_id, 1, 1, episodes_watched)
 
     @guard_against_none(None, 1)
     def _try_update_seasons(self, anilist_id, trakt_show_id, trakt_season_id=None):

--- a/resources/lib/indexers/anilist.py
+++ b/resources/lib/indexers/anilist.py
@@ -36,6 +36,7 @@ class AnilistAPI(ApiBase):
             'search/anime/genre': self.anime_genre_query,
             'search/anime': self.anime_search_query,
             'search/anime/recommendations': self.anime_recommendation_query,
+            'anime/specificid': self.anime_specific_query
             }
 
         self.TranslationNormalization = [
@@ -389,6 +390,11 @@ class AnilistAPI(ApiBase):
             self._URL, query_path='anime/id', variables=variables, dict_key=dict_key)[0]
         
         return show
+
+    @staticmethod
+    def anime_specific_query():
+        query = "query ($idMal: [Int], $page: Int = 1) {Page(page: $page, perPage: 100) {pageInfo {total perPage currentPage lastPage hasNextPage}media(idMal_in: $idMal, type: ANIME) {id idMal title{userPreferred english}coverImage{extraLarge large color}startDate{year month day}endDate{year month day}bannerImage season description type format status(version:2) episodes duration chapters volumes genres isAdult averageScore popularity nextAiringEpisode{airingAt timeUntilAiring episode}mediaListEntry{id status}studios(isMain:true){edges{isMain node{id name}}}}}}"
+        return query
 
     @staticmethod
     def anime_list_query():

--- a/resources/lib/ui/database.py
+++ b/resources/lib/ui/database.py
@@ -305,6 +305,22 @@ def add_mapping_id(anilist_id, column, value):
     cursor.close()
     control.try_release_lock(migrate_db_lock)
 
+def add_mapping_id_mal(mal_id, column, value):
+    migrate_db_lock.acquire()
+    cursor = _get_cursor()
+    cursor.execute('UPDATE shows SET %s=? WHERE mal_id=?' % column, (value, mal_id))
+    cursor.connection.commit()
+    cursor.close()
+    control.try_release_lock(migrate_db_lock)
+
+def add_update_shows_episodes_watched(anilist_id, column, value, episode):
+    migrate_db_lock.acquire()
+    cursor = _get_cursor()
+    cursor.execute('UPDATE episodes SET %s=? WHERE anilist_id=? AND number=?' % column, (value, anilist_id, episode))
+    cursor.connection.commit()
+    cursor.close()
+    control.try_release_lock(migrate_db_lock)
+
 def add_fanart(anilist_id, kodi_meta):
     migrate_db_lock.acquire()
     cursor = _get_cursor()
@@ -434,6 +450,14 @@ def mark_episode_unwatched_by_id():
     migrate_db_lock.acquire()
     cursor = _get_connection_cursor(g.ANILIST_SYNC_DB_PATH)
     cursor.execute('UPDATE shows SET trakt_id=? WHERE anilist_id=?', (69, 2))
+    cursor.connection.commit()
+    cursor.close()
+    control.try_release_lock(migrate_db_lock)
+
+def mark_episodes_watched(anilist_id, value, start_value, number_watched):
+    migrate_db_lock.acquire()
+    cursor = _get_connection_cursor(g.ANILIST_SYNC_DB_PATH)
+    cursor.execute('UPDATE episodes SET watched=? WHERE anilist_id=? AND number BETWEEN ? AND ?', (value, anilist_id, start_value, number_watched))
     cursor.connection.commit()
     cursor.close()
     control.try_release_lock(migrate_db_lock)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -123,7 +123,7 @@
 		<setting id="sep"/>
 		<setting id="watchlist.update.enabled" label="40346" type="bool" default="false"/>
 		<setting id="watchlist.update.flavor" type="labelenum" subsetting="true" label="40347" values="MAL|Kitsu|AniList" default="MAL" visible="eq(-1,true)"/>
-
+		<setting id="watchlist.watched.update" type="action" subsetting="true" label="40382" option="close" action="RunPlugin(plugin://plugin.video.kaito?action=watchlist_watched_update&modal=true)" visible="eq(-2,true)"/>
 		<!-- Anilist -->
 		<setting type="lsep" label="40348"/>
 		<setting id="sep"/>


### PR DESCRIPTION
Imports MAL watchlist. Any episodes you mark as watched on MAL are imported to local kaito database.
Will check your watchlist every time you hit the base page.
You have to check Update Watchlist option and select MAL as your watchlist.
Added Manual Watchlist update option