### PR TITLE
Make nyaa scraping handle parts more like tmdb helper. Also fix anilist watchlist loading for certain shows.

### DIFF
--- a/resources/lib/indexers/anilist.py
+++ b/resources/lib/indexers/anilist.py
@@ -207,7 +207,6 @@ class AnilistAPI(ApiBase):
         :param params: URL params for request
         :return: JSON response
         """
-
         get_dict = params.pop('dict_key')
         query_path = params.pop('query_path')
         if query_path:
@@ -838,7 +837,9 @@ class AnilistAPI_animelist(ApiBase):
         return result
 
     def _get_title(self, item):
-        title = item.get(self.title_language, item.get('userPreferred'))
+        title = item.get(self.title_language)
+        if not title:
+            title = item.get('userPreferred')
         title = title.encode('ascii','ignore').decode("utf-8")
         return title
 


### PR DESCRIPTION
Nyaa scraping improvements for seasons with parts. Changed it to handle episodes like when tmdb helper passes data. 
Also fix @TaiDak's last issue with Anilist Watchlists.