### PR TITLE
Fix simkl indexers shows. Fix 'mark as watched' for non integrated watchlist users

### DIFF
--- a/resources/lib/indexers/simkl.py
+++ b/resources/lib/indexers/simkl.py
@@ -405,11 +405,13 @@ class SIMKLAPI(ApiBase):
                     "args": self._create_args(item_information, episode["episode"]),
                 }
             )
-            tmp = self._parse_episode_view(episode, item_information['anilist_id'], None, None,
-                                     item_information['watched_episodes'], None)
-            ret.append(tmp)
-
-        return ret
+            if g.get_bool_setting('general.menus'):
+                tmp = self._parse_episode_view(episode, item_information['anilist_id'], None, None, item_information['watched_episodes'], None)
+                ret.append(tmp)
+        if g.get_bool_setting("general.menus"):
+            return ret
+        else:
+            return self._handle_response(episodes)
 
 
     def get_simkl_id(self, item_information):

--- a/resources/lib/ui/database.py
+++ b/resources/lib/ui/database.py
@@ -481,6 +481,15 @@ def mark_episodes_watched(anilist_id, value, start_value, number_watched):
     cursor.close()
     control.try_release_lock(migrate_db_lock)
 
+def checkPlayed(url):
+    migrate_db_lock.acquire()
+    cursor = _get_connection_cursor(g.KODI_VIDEO_DB_PATH)
+    cursor.execute('SELECT playCount FROM files WHERE strFilename = ?',  [url])
+    shows = cursor.fetchone()
+    cursor.close()
+    control.try_release_lock(migrate_db_lock)
+    return shows
+
 def remove_season(anilist_id):
     migrate_db_lock.acquire()
     cursor = _get_cursor()


### PR DESCRIPTION
Some simkl tracked shows were broken by my kaito 10 menu implementation. (I ran into Gintama not working).
 
For #29 , I have fixed it IF  you have watchlist update turned off. 
I could have it work with both, but I think if you're using an integrated watchlist, you'd just want that rather than a local only watchlist. I'm open to feedback on that though.